### PR TITLE
Fixed duplicated 'Columns' <dt>

### DIFF
--- a/internal/template.html
+++ b/internal/template.html
@@ -12,7 +12,7 @@
     <dl>
         <dt>Columns</dt>
         <dd>{{ .NCols }}</dd>
-        <dt>Columns</dt>
+        <dt>Rows</dt>
         <dd>{{ .NRows }}</dd>
     </dl>
 


### PR DESCRIPTION
`Columns` was duplicated in the second`<dt>`. It is now `Rows` as intended.